### PR TITLE
grep -v doesn't seem like the right thing we want here

### DIFF
--- a/ios.sh
+++ b/ios.sh
@@ -35,7 +35,7 @@ grep -r -H -i -n -e "delete" $pp
 grep -r -H -i -n  -e "select" $pp
 grep -r -H -i -n  -e "table" $pp
 grep -r -H -i -n -e "cursor" $pp
-grep -r -H -i -n -v "import" $pp
+grep -r -H -i -n -e "import" $pp
 echo ""
 echo "#######################################################################"
 echo "# Password References:                                                #"


### PR DESCRIPTION
`grep -v` would search for every lines that don't contain "import", basically most of the lines.

PS: feel free to close this PR if I understand it wrongly. Also my grep-fu is not that great to make it actually `Check for SQLi (%@ and no ? in SQL Statement)` so this is the best I can do.
